### PR TITLE
platform: nrf5340: target-cfg header

### DIFF
--- a/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017-2019 Arm Limited
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __TARGET_CFG_H__
+#define __TARGET_CFG_H__
+
+#include "tfm_plat_defs.h"
+
+#define TFM_DRIVER_STDIO    Driver_USART0
+#define NS_DRIVER_STDIO     Driver_USART0
+
+/**
+ * \brief Store the addresses of memory regions
+ */
+struct memory_region_limits {
+    uint32_t non_secure_code_start;
+    uint32_t non_secure_partition_base;
+    uint32_t non_secure_partition_limit;
+    uint32_t veneer_base;
+    uint32_t veneer_limit;
+#ifdef BL2
+    uint32_t secondary_partition_base;
+    uint32_t secondary_partition_limit;
+#endif /* BL2 */
+};
+
+/**
+ * \brief Configures the Security Protection Unit.
+ *
+ * \return  Returns error code.
+ */
+int32_t spu_init_cfg(void);
+
+/**
+ * \brief Clears SPU interrupt.
+ */
+void spu_clear_irq(void);
+
+/**
+ * \brief Configures SAU and IDAU.
+ */
+void sau_and_idau_cfg(void);
+
+/**
+ * \brief Enables the fault handlers and sets priorities.
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t enable_fault_handlers(void);
+
+/**
+ * \brief Configures the system reset request properties
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t system_reset_cfg(void);
+
+/**
+ * \brief Configures the system debug properties.
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t init_debug(void);
+
+/**
+ * \brief Configures all external interrupts to target the
+ *        NS state, apart for the ones associated to secure
+ *        peripherals (plus SPU)
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void);
+
+/**
+ * \brief This function enable the interrupts associated
+ *        to the secure peripherals (plus the isolation boundary violation
+ *        interrupts)
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t nvic_interrupt_enable(void);
+
+#endif /* __TARGET_CFG_H__ */

--- a/platform/ext/target/nordic_nrf/nrf9160/target_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf9160/target_cfg.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017-2019 Arm Limited
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __TARGET_CFG_H__
+#define __TARGET_CFG_H__
+
+#include "tfm_plat_defs.h"
+
+#define TFM_DRIVER_STDIO    Driver_USART0
+#define NS_DRIVER_STDIO     Driver_USART0
+
+/**
+ * \brief Store the addresses of memory regions
+ */
+struct memory_region_limits {
+    uint32_t non_secure_code_start;
+    uint32_t non_secure_partition_base;
+    uint32_t non_secure_partition_limit;
+    uint32_t veneer_base;
+    uint32_t veneer_limit;
+#ifdef BL2
+    uint32_t secondary_partition_base;
+    uint32_t secondary_partition_limit;
+#endif /* BL2 */
+};
+
+/**
+ * \brief Configures the Security Protection Unit.
+ *
+ * \return  Returns error code.
+ */
+int32_t spu_init_cfg(void);
+
+/**
+ * \brief Clears SPU interrupt.
+ */
+void spu_clear_irq(void);
+
+/**
+ * \brief Configures SAU and IDAU.
+ */
+void sau_and_idau_cfg(void);
+
+/**
+ * \brief Enables the fault handlers and sets priorities.
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t enable_fault_handlers(void);
+
+/**
+ * \brief Configures the system reset request properties
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t system_reset_cfg(void);
+
+/**
+ * \brief Configures the system debug properties.
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t init_debug(void);
+
+/**
+ * \brief Configures all external interrupts to target the
+ *        NS state, apart for the ones associated to secure
+ *        peripherals (plus SPU)
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void);
+
+/**
+ * \brief This function enable the interrupts associated
+ *        to the secure peripherals (plus the isolation boundary violation
+ *        interrupts)
+ *
+ * \return Returns values as specified by the \ref tfm_plat_err_t
+ */
+enum tfm_plat_err_t nvic_interrupt_enable(void);
+
+#endif /* __TARGET_CFG_H__ */


### PR DESCRIPTION
Commit the initial version of the target-cfg header
for nrf5340 platform. At the initial state, this
header only specifies the core platform-specific API,
not the API for peripheral security configuration.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

**_Edit: duplicated this header for nRF9160._**