### PR TITLE
platform: nrf5340: adding flash layout information

### DIFF
--- a/platform/ext/target/nordic_nrf/nrf5340/partition/flash_layout.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/partition/flash_layout.h
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2018-2020 Arm Limited. All rights reserved.
+ * Copyright (c) 2020 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __FLASH_LAYOUT_H__
+#define __FLASH_LAYOUT_H__
+
+/* Flash layout on NRF5340 Application MCU with BL2:
+ *
+ * 0x0000_0000 BL2 - MCUBoot (64 KB)
+ * 0x0001_0000 Primary image area (448 KB):
+ *    0x0001_0000 Secure     image primary (192 KB)
+ *    0x0004_0000 Non-secure image primary (256 KB)
+ * 0x0008_0000 Secondary image area (448 KB):
+ *    0x0008_0000 Secure     image secondary (192 KB)
+ *    0x000b_0000 Non-secure image secondary (256 KB)
+ * 0x000f_0000 Secure Storage Area (16 KB)
+ * 0x000f_4000 Internal Trusted Storage Area (8 KB)
+ * 0x000f_6000 NV counters area (4 KB)
+ * 0x000f_7000 Unused
+ *
+ * Flash layout on NRF5340 Application MCU without BL2:
+ *
+ * 0x0000_0000 Primary image area (960 KB):
+ *    0x0000_0000 Secure     image primary (480 KB)
+ *    0x0007_8000 Non-secure image primary (480 KB)
+ * 0x000f_0000 Secure Storage Area (16 KB)
+ * 0x000f_4000 Internal Trusted Storage Area (8 KB)
+ * 0x000f_6000 NV counters area (4 KB)
+ * 0x000f_7000 Unused
+ */
+
+/* This header file is included from linker scatter file as well, where only a
+ * limited C constructs are allowed. Therefore it is not possible to include
+ * here the platform_base_address.h to access flash related defines. To resolve
+ * this some of the values are redefined here with different names, these are
+ * marked with comment.
+ */
+
+/* Size of a Secure and of a Non-secure image */
+#define FLASH_S_PARTITION_SIZE                (0x30000)       /* S partition: 192 kB*/
+#define FLASH_NS_PARTITION_SIZE               (0x40000)       /* NS partition: 256 kB*/
+#define FLASH_MAX_PARTITION_SIZE        ((FLASH_S_PARTITION_SIZE >   \
+                                          FLASH_NS_PARTITION_SIZE) ? \
+                                         FLASH_S_PARTITION_SIZE :    \
+                                         FLASH_NS_PARTITION_SIZE)
+
+/* Sector size of the embedded flash hardware (erase/program) */
+#define FLASH_AREA_IMAGE_SECTOR_SIZE        (0x1000)           /* 4 KB. Flash memory program/erase operations have a page granularity. */
+
+/* FLASH size */
+#define FLASH_TOTAL_SIZE                    (0x100000)    /* 1024 kB. */
+
+/* Flash layout info for BL2 bootloader */
+#define FLASH_BASE_ADDRESS                  (0x00000000)
+
+#ifdef BL2
+/* Offset and size definitions of the flash partitions that are handled by the
+ * bootloader. The image swapping is done between IMAGE_PRIMARY and
+ * IMAGE_SECONDARY, SCRATCH is used as a temporary storage during image
+ * swapping.
+ */
+#define FLASH_AREA_BL2_OFFSET      (0x0)
+#define FLASH_AREA_BL2_SIZE        (0x10000) /* 64 KB */
+
+#if !defined(MCUBOOT_IMAGE_NUMBER) || (MCUBOOT_IMAGE_NUMBER == 1)
+/* Secure + Non-secure image primary slot */
+#define FLASH_AREA_0_ID            (1)
+#define FLASH_AREA_0_OFFSET        (FLASH_AREA_BL2_OFFSET + FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE + \
+                                    FLASH_NS_PARTITION_SIZE)
+/* Secure + Non-secure secondary slot */
+#define FLASH_AREA_2_ID            (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_2_OFFSET        (FLASH_AREA_0_OFFSET + FLASH_AREA_0_SIZE)
+#define FLASH_AREA_2_SIZE          (FLASH_S_PARTITION_SIZE + \
+                                    FLASH_NS_PARTITION_SIZE)
+/* Not used, only the Non-swapping firmware upgrade operation
+ * is supported on NRF5340 Application MCU.
+ */
+#define FLASH_AREA_SCRATCH_ID      (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET  (FLASH_AREA_2_OFFSET + FLASH_AREA_2_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE    (0)
+/* Maximum number of image sectors supported by the bootloader. */
+#define MCUBOOT_MAX_IMG_SECTORS    ((FLASH_S_PARTITION_SIZE + \
+                                     FLASH_NS_PARTITION_SIZE) / \
+                                    FLASH_AREA_IMAGE_SECTOR_SIZE)
+#elif (MCUBOOT_IMAGE_NUMBER == 2)
+/* Secure image primary slot */
+#define FLASH_AREA_0_ID            (1)
+#define FLASH_AREA_0_OFFSET        (FLASH_AREA_BL2_OFFSET + FLASH_AREA_BL2_SIZE)
+#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE)
+/* Non-secure image primary slot */
+#define FLASH_AREA_1_ID            (FLASH_AREA_0_ID + 1)
+#define FLASH_AREA_1_OFFSET        (FLASH_AREA_0_OFFSET + FLASH_AREA_0_SIZE)
+#define FLASH_AREA_1_SIZE          (FLASH_NS_PARTITION_SIZE)
+/* Secure image secondary slot */
+#define FLASH_AREA_2_ID            (FLASH_AREA_1_ID + 1)
+#define FLASH_AREA_2_OFFSET        (FLASH_AREA_1_OFFSET + FLASH_AREA_1_SIZE)
+#define FLASH_AREA_2_SIZE          (FLASH_S_PARTITION_SIZE)
+/* Non-secure image secondary slot */
+#define FLASH_AREA_3_ID            (FLASH_AREA_2_ID + 1)
+#define FLASH_AREA_3_OFFSET        (FLASH_AREA_2_OFFSET + FLASH_AREA_2_SIZE)
+#define FLASH_AREA_3_SIZE          (FLASH_NS_PARTITION_SIZE)
+/* Not used, only the Non-swapping firmware upgrade operation
+ * is supported on NRF5340 Application MCU.
+ */
+#define FLASH_AREA_SCRATCH_ID      (FLASH_AREA_3_ID + 1)
+#define FLASH_AREA_SCRATCH_OFFSET  (FLASH_AREA_3_OFFSET + FLASH_AREA_3_SIZE)
+#define FLASH_AREA_SCRATCH_SIZE    (0)
+/* Maximum number of image sectors supported by the bootloader. */
+#define MCUBOOT_MAX_IMG_SECTORS    (FLASH_MAX_PARTITION_SIZE / \
+                                    FLASH_AREA_IMAGE_SECTOR_SIZE)
+#else /* MCUBOOT_IMAGE_NUMBER > 2 */
+#error "Only MCUBOOT_IMAGE_NUMBER 1 and 2 are supported!"
+#endif /* MCUBOOT_IMAGE_NUMBER */
+
+/* Not used, only the Non-swapping firmware upgrade operation
+ * is supported on nRF5340. The maximum number of status entries
+ * supported by the bootloader.
+ */
+#define MCUBOOT_STATUS_MAX_ENTRIES      (0)
+
+#else
+
+/* Secure + Non-secure image primary slot */
+#define FLASH_AREA_0_ID            (1)
+#define FLASH_AREA_0_OFFSET        (0x0)
+#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE + \
+                                    FLASH_NS_PARTITION_SIZE)
+
+#endif /* BL2 */
+
+#define FLASH_SST_AREA_OFFSET           (FLASH_AREA_SCRATCH_OFFSET + \
+                                         FLASH_AREA_SCRATCH_SIZE)
+#define FLASH_SST_AREA_SIZE             (0x4000)   /* 16 KB */
+
+/* Internal Trusted Storage (ITS) Service definitions */
+#define FLASH_ITS_AREA_OFFSET           (FLASH_SST_AREA_OFFSET + \
+                                         FLASH_SST_AREA_SIZE)
+#define FLASH_ITS_AREA_SIZE             (0x2000)   /* 8 KB */
+
+/* NV Counters definitions */
+#define FLASH_NV_COUNTERS_AREA_OFFSET   (FLASH_ITS_AREA_OFFSET + \
+                                         FLASH_ITS_AREA_SIZE)
+#define FLASH_NV_COUNTERS_AREA_SIZE     (FLASH_AREA_IMAGE_SECTOR_SIZE)
+
+/* Offset and size definition in flash area used by assemble.py */
+#define SECURE_IMAGE_OFFSET             (0x0)
+#define SECURE_IMAGE_MAX_SIZE           FLASH_S_PARTITION_SIZE
+
+#define NON_SECURE_IMAGE_OFFSET         (SECURE_IMAGE_OFFSET + \
+                                         SECURE_IMAGE_MAX_SIZE)
+#define NON_SECURE_IMAGE_MAX_SIZE       FLASH_NS_PARTITION_SIZE
+
+/* Flash device name used by BL2
+ * Name is defined in flash driver file: Driver_Flash.c
+ */
+#define FLASH_DEV_NAME Driver_FLASH0
+
+/* Secure Storage (SST) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M SST Integration Guide.
+ */
+#define SST_FLASH_DEV_NAME Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+#define SST_FLASH_AREA_ADDR     FLASH_SST_AREA_OFFSET
+/* Dedicated flash area for SST */
+#define SST_FLASH_AREA_SIZE     FLASH_SST_AREA_SIZE
+#define SST_SECTOR_SIZE         FLASH_AREA_IMAGE_SECTOR_SIZE
+/* Number of SST_SECTOR_SIZE per block */
+#define SST_SECTORS_PER_BLOCK   (0x1)
+/* Specifies the smallest flash programmable unit in bytes */
+#define SST_FLASH_PROGRAM_UNIT  FLASH_AREA_IMAGE_SECTOR_SIZE
+
+/* The maximum asset size to be stored in the SST area */
+#define SST_MAX_ASSET_SIZE      (2048)
+/* The maximum number of assets to be stored in the SST area */
+#define SST_NUM_ASSETS          (5)
+
+/* Internal Trusted Storage (ITS) Service definitions
+ * Note: Further documentation of these definitions can be found in the
+ * TF-M ITS Integration Guide. The ITS should be in the internal flash, but is
+ * allocated in the external flash just for development platforms that don't
+ * have internal flash available.
+ */
+#define ITS_FLASH_DEV_NAME Driver_FLASH0
+
+/* In this target the CMSIS driver requires only the offset from the base
+ * address instead of the full memory address.
+ */
+#define ITS_FLASH_AREA_ADDR     FLASH_ITS_AREA_OFFSET
+/* Dedicated flash area for ITS */
+#define ITS_FLASH_AREA_SIZE     FLASH_ITS_AREA_SIZE
+#define ITS_SECTOR_SIZE         FLASH_AREA_IMAGE_SECTOR_SIZE
+/* Number of ITS_SECTOR_SIZE per block */
+#define ITS_SECTORS_PER_BLOCK   (0x1)
+/* Specifies the smallest flash programmable unit in bytes */
+#define ITS_FLASH_PROGRAM_UNIT  FLASH_AREA_IMAGE_SECTOR_SIZE
+
+/* The maximum asset size to be stored in the ITS area */
+#define ITS_MAX_ASSET_SIZE      (512)
+/* The maximum number of assets to be stored in the ITS area */
+#define ITS_NUM_ASSETS          (5)
+
+/* NV Counters definitions */
+#define TFM_NV_COUNTERS_AREA_ADDR    FLASH_NV_COUNTERS_AREA_OFFSET
+#define TFM_NV_COUNTERS_AREA_SIZE    FLASH_NV_COUNTERS_AREA_SIZE
+#define TFM_NV_COUNTERS_SECTOR_ADDR  FLASH_NV_COUNTERS_AREA_OFFSET
+#define TFM_NV_COUNTERS_SECTOR_SIZE  FLASH_AREA_IMAGE_SECTOR_SIZE
+
+/* Use Flash memory to store Code data */
+#define S_ROM_ALIAS_BASE  (0x00000000)
+#define NS_ROM_ALIAS_BASE (0x00000000)
+
+/* Use SRAM memory to store RW data */
+#define S_RAM_ALIAS_BASE  (0x20000000)
+#define NS_RAM_ALIAS_BASE (0x20000000)
+
+#define TOTAL_ROM_SIZE FLASH_TOTAL_SIZE
+#define TOTAL_RAM_SIZE (0x00080000)     /* 512 kB */
+
+#endif /* __FLASH_LAYOUT_H__ */

--- a/platform/ext/target/nordic_nrf/nrf5340/partition/region_defs.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/partition/region_defs.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2017-2020 Arm Limited. All rights reserved.
+ * Copyright (c) 2020 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __REGION_DEFS_H__
+#define __REGION_DEFS_H__
+
+#include "flash_layout.h"
+
+#define BL2_HEAP_SIZE           (0x00001000)
+#define BL2_MSP_STACK_SIZE      (0x00001800)
+
+#define S_HEAP_SIZE             (0x00001000)
+#define S_MSP_STACK_SIZE_INIT   (0x00000400)
+#define S_MSP_STACK_SIZE        (0x00000800)
+#define S_PSP_STACK_SIZE        (0x00000800)
+
+#define NS_HEAP_SIZE            (0x00001000)
+#define NS_MSP_STACK_SIZE       (0x00000400)
+#define NS_PSP_STACK_SIZE       (0x00000C00)
+
+/* Size of nRF SPU (Nordic IDAU) regions */
+#define SPU_FLASH_REGION_SIZE   (0x00008000)
+
+/* This size of buffer is big enough to store an attestation
+ * token produced by initial attestation service
+ */
+#define PSA_INITIAL_ATTEST_TOKEN_MAX_SIZE   (0x250)
+
+/*
+ * SPU flash region granularity is 32 KB on nRF5340. Alignment
+ * of partitions is defined in accordance with this constraint.
+ */
+#ifdef BL2
+#ifndef LINK_TO_SECONDARY_PARTITION
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET   (FLASH_AREA_0_OFFSET)
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET (FLASH_AREA_2_OFFSET)
+#else
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET   (FLASH_AREA_2_OFFSET)
+#define S_IMAGE_SECONDARY_PARTITION_OFFSET (FLASH_AREA_0_OFFSET)
+#endif /* !LINK_TO_SECONDARY_PARTITION */
+#else
+#define S_IMAGE_PRIMARY_PARTITION_OFFSET (0x0)
+#endif /* BL2 */
+
+#ifndef LINK_TO_SECONDARY_PARTITION
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_0_OFFSET \
+                                           + FLASH_S_PARTITION_SIZE)
+#else
+#define NS_IMAGE_PRIMARY_PARTITION_OFFSET (FLASH_AREA_2_OFFSET \
+                                           + FLASH_S_PARTITION_SIZE)
+#endif /* !LINK_TO_SECONDARY_PARTITION */
+
+/* Boot partition structure if MCUBoot is used:
+ * 0x0_0000 Bootloader header
+ * 0x0_0400 Image area
+ * 0x0_FC00 Trailer
+ */
+/* IMAGE_CODE_SIZE is the space available for the software binary image.
+ * It is less than the FLASH_S_PARTITION_SIZE + FLASH_NS_PARTITION_SIZE
+ * because we reserve space for the image header and trailer introduced
+ * by the bootloader.
+ */
+#ifdef BL2
+#define BL2_HEADER_SIZE      (0x400)       /* 1 KB */
+#define BL2_TRAILER_SIZE     (0x400)       /* 1 KB */
+#else
+/* No header if no bootloader, but keep IMAGE_CODE_SIZE the same */
+#define BL2_HEADER_SIZE      (0x0)
+#define BL2_TRAILER_SIZE     (0x800)
+#endif /* BL2 */
+
+#define IMAGE_S_CODE_SIZE \
+            (FLASH_S_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+#define IMAGE_NS_CODE_SIZE \
+            (FLASH_NS_PARTITION_SIZE - BL2_HEADER_SIZE - BL2_TRAILER_SIZE)
+
+/* The CMSE veneers shall be placed in an NSC region
+ * which will be placed in a secure SPU region defined
+ * in the beginning of the secure flash region.
+ */
+#define CMSE_VENEER_REGION_SIZE     (0x400)
+
+/* Alias definitions for secure and non-secure areas*/
+#define S_ROM_ALIAS(x)  (S_ROM_ALIAS_BASE + (x))
+#define NS_ROM_ALIAS(x) (NS_ROM_ALIAS_BASE + (x))
+
+#define S_RAM_ALIAS(x)  (S_RAM_ALIAS_BASE + (x))
+#define NS_RAM_ALIAS(x) (NS_RAM_ALIAS_BASE + (x))
+
+/* Secure regions */
+#define S_IMAGE_PRIMARY_AREA_OFFSET \
+             (S_IMAGE_PRIMARY_PARTITION_OFFSET + SPU_FLASH_REGION_SIZE)
+#define S_CODE_START    (S_ROM_ALIAS(S_IMAGE_PRIMARY_AREA_OFFSET))
+#define S_CODE_SIZE     (IMAGE_S_CODE_SIZE - (SPU_FLASH_REGION_SIZE - BL2_HEADER_SIZE))
+#define S_CODE_LIMIT    (S_CODE_START + S_CODE_SIZE - 1)
+
+#define S_DATA_START    (S_RAM_ALIAS(0x0))
+#define S_DATA_SIZE     (TOTAL_RAM_SIZE / 2)
+#define S_DATA_LIMIT    (S_DATA_START + S_DATA_SIZE - 1)
+
+/* CMSE Veneers region */
+#define CMSE_VENEER_REGION_START  (S_IMAGE_PRIMARY_AREA_OFFSET - CMSE_VENEER_REGION_SIZE)
+
+/* Non-secure regions */
+#define NS_IMAGE_PRIMARY_AREA_OFFSET \
+                        (NS_IMAGE_PRIMARY_PARTITION_OFFSET + BL2_HEADER_SIZE)
+#define NS_CODE_START   (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_AREA_OFFSET))
+#define NS_CODE_SIZE    (IMAGE_NS_CODE_SIZE)
+#define NS_CODE_LIMIT   (NS_CODE_START + NS_CODE_SIZE - 1)
+
+#define NS_DATA_START   (NS_RAM_ALIAS(S_DATA_SIZE))
+#define NS_DATA_SIZE    (TOTAL_RAM_SIZE - S_DATA_SIZE)
+#define NS_DATA_LIMIT   (NS_DATA_START + NS_DATA_SIZE - 1)
+
+/* NS partition information is used for SPU configuration */
+#define NS_PARTITION_START \
+            (NS_ROM_ALIAS(NS_IMAGE_PRIMARY_PARTITION_OFFSET))
+#define NS_PARTITION_SIZE (FLASH_NS_PARTITION_SIZE)
+
+/* Secondary partition for new images in case of firmware upgrade */
+#define SECONDARY_PARTITION_START \
+            (NS_ROM_ALIAS(S_IMAGE_SECONDARY_PARTITION_OFFSET))
+#define SECONDARY_PARTITION_SIZE (FLASH_S_PARTITION_SIZE + \
+                                  FLASH_NS_PARTITION_SIZE)
+
+#ifdef BL2
+/* Bootloader regions */
+#define BL2_CODE_START    (S_ROM_ALIAS(FLASH_AREA_BL2_OFFSET))
+#define BL2_CODE_SIZE     (FLASH_AREA_BL2_SIZE)
+#define BL2_CODE_LIMIT    (BL2_CODE_START + BL2_CODE_SIZE - 1)
+
+#define BL2_DATA_START    (S_RAM_ALIAS(0x0))
+#define BL2_DATA_SIZE     (TOTAL_RAM_SIZE)
+#define BL2_DATA_LIMIT    (BL2_DATA_START + BL2_DATA_SIZE - 1)
+#endif /* BL2 */
+
+/* Shared data area between bootloader and runtime firmware.
+ * Shared data area is allocated at the beginning of the RAM, it is overlapping
+ * with TF-M Secure code's MSP stack
+ */
+#define BOOT_TFM_SHARED_DATA_BASE S_RAM_ALIAS_BASE
+#define BOOT_TFM_SHARED_DATA_SIZE (0x400)
+#define BOOT_TFM_SHARED_DATA_LIMIT (BOOT_TFM_SHARED_DATA_BASE + \
+                                    BOOT_TFM_SHARED_DATA_SIZE - 1)
+
+#endif /* __REGION_DEFS_H__ */


### PR DESCRIPTION
We are introducing the flash layout information for the
nRF5340 target, to be used in memory partitioning.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

- Pushing this for feedback, while working on region_defs.h header.
flash_layout.h should introduce the flash partitioning for nRF530 APP MCU target.
- The default partitioning is meant to work with upstream Zephyr samples/tests.
- Care has been taken so this partitioning looks like upstream Zephyr flash partitioning, so TF-M is compatible with Zephyr. (But note that, at the end of the day, any upstream overlays, and/or partition manager (downstream) may override flash partitioning.)

- Secure Storage and Internal Trusted Firmware partitions are placed on the flash area that Zephyr defines as image scratch.

- **_update_**: pushed the region_defs.h. as well.
