### PR TITLE
Tfm platform peripheral defs

### DIFF
--- a/platform/ext/target/nordic_nrf/nrf5340/tfm_peripherals_def.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/tfm_peripherals_def.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018-2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2020, Cypress Semiconductor Corporation. All rights reserved.
+ * Copyright (c) 2020, Nordic Semiconductor ASA. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef __TFM_PERIPHERALS_DEF_H__
+#define __TFM_PERIPHERALS_DEF_H__
+
+#include <nrf.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TFM_TIMER0_IRQ    (TIMER0_IRQn)
+#define TFM_TIMER1_IRQ    (TIMER1_IRQn)
+
+struct tfm_spm_partition_platform_data_t;
+
+extern struct tfm_spm_partition_platform_data_t tfm_peripheral_std_uart;
+extern struct tfm_spm_partition_platform_data_t tfm_peripheral_timer0;
+
+#define TFM_PERIPHERAL_STD_UART     (&tfm_peripheral_std_uart)
+#define TFM_PERIPHERAL_TIMER0       (&tfm_peripheral_timer0)
+#define TFM_PERIPHERAL_FPGA_IO      (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TFM_PERIPHERALS_DEF_H__ */

--- a/platform/ext/target/nordic_nrf/nrf9160/tfm_peripherals_def.h
+++ b/platform/ext/target/nordic_nrf/nrf9160/tfm_peripherals_def.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018-2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2020, Cypress Semiconductor Corporation. All rights reserved.
+ * Copyright (c) 2020, Nordic Semiconductor ASA. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef __TFM_PERIPHERALS_DEF_H__
+#define __TFM_PERIPHERALS_DEF_H__
+
+#include <nrf.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TFM_TIMER0_IRQ    (TIMER0_IRQn)
+#define TFM_TIMER1_IRQ    (TIMER1_IRQn)
+
+struct tfm_spm_partition_platform_data_t;
+
+extern struct tfm_spm_partition_platform_data_t tfm_peripheral_std_uart;
+extern struct tfm_spm_partition_platform_data_t tfm_peripheral_timer0;
+
+#define TFM_PERIPHERAL_STD_UART     (&tfm_peripheral_std_uart)
+#define TFM_PERIPHERAL_TIMER0       (&tfm_peripheral_timer0)
+#define TFM_PERIPHERAL_FPGA_IO      (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TFM_PERIPHERALS_DEF_H__ */


### PR DESCRIPTION
Introducing peripheral_defs.h header for nrf5340 and nrf9160
This is as simple as it can be for the initial port.
Following the way the headers are populated for other targets.