### PR TITLE
platform: nordic: implement tfm_platform_system.h API

### DIFF
--- a/platform/ext/target/nordic_nrf/nrf5340/services/src/tfm_platform_system.c
+++ b/platform/ext/target/nordic_nrf/nrf5340/services/src/tfm_platform_system.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "platform/include/tfm_platform_system.h"
+#include "cmsis.h"
+
+void tfm_platform_hal_system_reset(void)
+{
+    /* Reset the system */
+    NVIC_SystemReset();
+}
+
+enum tfm_platform_err_t tfm_platform_hal_ioctl(tfm_platform_ioctl_req_t request,
+                                               psa_invec  *in_vec,
+                                               psa_outvec *out_vec)
+{
+    (void)request;
+    (void)in_vec;
+    (void)out_vec;
+
+    /* Not needed for this platform */
+    return TFM_PLATFORM_ERR_NOT_SUPPORTED;
+}

--- a/platform/ext/target/nordic_nrf/nrf9160/services/src/tfm_platform_system.c
+++ b/platform/ext/target/nordic_nrf/nrf9160/services/src/tfm_platform_system.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "platform/include/tfm_platform_system.h"
+#include "cmsis.h"
+
+void tfm_platform_hal_system_reset(void)
+{
+    /* Reset the system */
+    NVIC_SystemReset();
+}
+
+enum tfm_platform_err_t tfm_platform_hal_ioctl(tfm_platform_ioctl_req_t request,
+                                               psa_invec  *in_vec,
+                                               psa_outvec *out_vec)
+{
+    (void)request;
+    (void)in_vec;
+    (void)out_vec;
+
+    /* Not needed for this platform */
+    return TFM_PLATFORM_ERR_NOT_SUPPORTED;
+}


### PR DESCRIPTION
Implement the target-specific internal API, described
in tfm_platform_system.h, for nRF5340 and nrf9160 targets.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>

Note: for now the implementation concerns only System Reset (as in most of the upstream platforms, i.e. except Musca A and B1).
The implementation of GPIO and PIN services can be added at a later stage, if required.