### PR TITLE
platform: nordic_nrf: Add CMSIS USART driver

### DIFF
--- a/platform/ext/target/nordic_nrf/common/cmsis_drivers/Driver_USART.c
+++ b/platform/ext/target/nordic_nrf/common/cmsis_drivers/Driver_USART.c
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2013-2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2020 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <Driver_USART.h>
+#include <RTE_Device.h>
+#include <nrfx_uarte.h>
+
+#ifndef ARG_UNUSED
+#define ARG_UNUSED(arg)  (void)arg
+#endif
+
+#define ARM_USART_DRV_VERSION  ARM_DRIVER_VERSION_MAJOR_MINOR(2, 2)
+
+#if RTE_USART0 || RTE_USART1 || RTE_USART2 || RTE_USART3
+
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_USART_API_VERSION,
+    ARM_USART_DRV_VERSION
+};
+
+static const ARM_USART_CAPABILITIES DriverCapabilities = {
+    .asynchronous = 1,
+};
+
+typedef struct {
+    const nrfx_uarte_t   uarte;
+    const nrfx_uarte_config_t *initial_config;
+    size_t               tx_count;
+    size_t               rx_count;
+    nrf_uarte_config_t   hal_cfg;
+    nrf_uarte_baudrate_t baudrate;
+} UARTx_Resources;
+
+static ARM_DRIVER_VERSION ARM_USART_GetVersion(void)
+{
+    return DriverVersion;
+}
+
+static ARM_USART_CAPABILITIES ARM_USART_GetCapabilities(void)
+{
+    return DriverCapabilities;
+}
+
+static int32_t ARM_USARTx_Initialize(ARM_USART_SignalEvent_t cb_event,
+                                     UARTx_Resources *uart_resources)
+{
+    ARG_UNUSED(cb_event);
+
+    nrfx_err_t err_code = nrfx_uarte_init(&uart_resources->uarte,
+                                          uart_resources->initial_config,
+                                          NULL);
+    if (err_code != NRFX_SUCCESS) {
+        return ARM_DRIVER_ERROR_BUSY;
+    }
+
+    uart_resources->tx_count = 0;
+    uart_resources->rx_count = 0;
+    uart_resources->hal_cfg  = uart_resources->initial_config->hal_cfg;
+    uart_resources->baudrate = uart_resources->initial_config->baudrate;
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_USARTx_Uninitialize(UARTx_Resources *uart_resources)
+{
+    nrfx_uarte_uninit(&uart_resources->uarte);
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_USARTx_PowerControl(ARM_POWER_STATE state,
+                                       UARTx_Resources *uart_resources)
+{
+    ARG_UNUSED(uart_resources);
+
+    switch (state) {
+    case ARM_POWER_FULL:
+        /* Nothing to be done */
+        return ARM_DRIVER_OK;
+
+    case ARM_POWER_OFF:
+    case ARM_POWER_LOW:
+    default:
+        return ARM_DRIVER_ERROR_UNSUPPORTED;
+    }
+}
+
+static int32_t ARM_USARTx_Send(const void *data, uint32_t num,
+                               UARTx_Resources *uart_resources)
+{
+    nrfx_err_t err_code = nrfx_uarte_tx(&uart_resources->uarte, data, num);
+    if (err_code == NRFX_ERROR_BUSY) {
+        return ARM_DRIVER_ERROR_BUSY;
+    } else if (err_code != NRFX_SUCCESS) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    uart_resources->tx_count = num;
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_USARTx_Receive(void *data, uint32_t num,
+                                  UARTx_Resources *uart_resources)
+{
+    nrfx_err_t err_code = nrfx_uarte_rx(&uart_resources->uarte, data, num);
+    if (err_code == NRFX_ERROR_BUSY) {
+        return ARM_DRIVER_ERROR_BUSY;
+    } else if (err_code != NRFX_SUCCESS) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    uart_resources->rx_count = num;
+    return ARM_DRIVER_OK;
+}
+
+static int32_t ARM_USART_Transfer(const void *data_out, void *data_in,
+                                  uint32_t num)
+{
+    ARG_UNUSED(data_out);
+    ARG_UNUSED(data_in);
+    ARG_UNUSED(num);
+
+    return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static uint32_t ARM_USARTx_GetTxCount(const UARTx_Resources *uart_resources)
+{
+    return uart_resources->tx_count;
+}
+
+static uint32_t ARM_USARTx_GetRxCount(const UARTx_Resources *uart_resources)
+{
+    return uart_resources->rx_count;
+}
+
+static int32_t ARM_USARTx_Control(uint32_t control, uint32_t arg,
+                                  UARTx_Resources *uart_resources)
+{
+    if ((control & ARM_USART_CONTROL_Msk) != ARM_USART_MODE_ASYNCHRONOUS) {
+        return ARM_DRIVER_ERROR_UNSUPPORTED;
+    }
+
+    nrf_uarte_baudrate_t baudrate = uart_resources->baudrate;
+    nrf_uarte_config_t   hal_cfg  = uart_resources->hal_cfg;
+    switch (arg) {
+        case    1200: baudrate = NRF_UARTE_BAUDRATE_1200;    break;
+        case    2400: baudrate = NRF_UARTE_BAUDRATE_2400;    break;
+        case    4800: baudrate = NRF_UARTE_BAUDRATE_4800;    break;
+        case    9600: baudrate = NRF_UARTE_BAUDRATE_9600;    break;
+        case   14400: baudrate = NRF_UARTE_BAUDRATE_14400;   break;
+        case   19200: baudrate = NRF_UARTE_BAUDRATE_19200;   break;
+        case   28800: baudrate = NRF_UARTE_BAUDRATE_28800;   break;
+        case   31250: baudrate = NRF_UARTE_BAUDRATE_31250;   break;
+        case   38400: baudrate = NRF_UARTE_BAUDRATE_38400;   break;
+        case   56000: baudrate = NRF_UARTE_BAUDRATE_56000;   break;
+        case   57600: baudrate = NRF_UARTE_BAUDRATE_57600;   break;
+        case   76800: baudrate = NRF_UARTE_BAUDRATE_76800;   break;
+        case  115200: baudrate = NRF_UARTE_BAUDRATE_115200;  break;
+        case  230400: baudrate = NRF_UARTE_BAUDRATE_230400;  break;
+        case  250000: baudrate = NRF_UARTE_BAUDRATE_250000;  break;
+        case  460800: baudrate = NRF_UARTE_BAUDRATE_460800;  break;
+        case  921600: baudrate = NRF_UARTE_BAUDRATE_921600;  break;
+        case 1000000: baudrate = NRF_UARTE_BAUDRATE_1000000; break;
+        default:
+            return ARM_USART_ERROR_BAUDRATE;
+    }
+
+    if ((control & ARM_USART_DATA_BITS_Msk) != ARM_USART_DATA_BITS_8) {
+        return ARM_USART_ERROR_DATA_BITS;
+    }
+
+    switch (control & ARM_USART_STOP_BITS_Msk) {
+        case ARM_USART_STOP_BITS_1:
+            hal_cfg.stop = NRF_UARTE_STOP_ONE;
+            break;
+
+        case ARM_USART_STOP_BITS_2:
+            hal_cfg.stop = NRF_UARTE_STOP_TWO;
+            break;
+
+        default:
+            return ARM_USART_ERROR_STOP_BITS;
+    }
+
+    switch (control & ARM_USART_PARITY_Msk) {
+        case ARM_USART_PARITY_NONE:
+            hal_cfg.parity = NRF_UARTE_PARITY_EXCLUDED;
+            break;
+
+#if defined(UARTE_CONFIG_PARITYTYPE_Msk)
+        case ARM_USART_PARITY_EVEN:
+            hal_cfg.parity = NRF_UARTE_PARITY_INCLUDED;
+            hal_cfg.paritytype = NRF_UARTE_PARITYTYPE_EVEN;
+            break;
+
+        case ARM_USART_PARITY_ODD:
+            hal_cfg.parity = NRF_UARTE_PARITY_INCLUDED;
+            hal_cfg.paritytype = NRF_UARTE_PARITYTYPE_ODD;
+            break;
+#else
+        case ARM_USART_PARITY_EVEN:
+            hal_cfg.parity = NRF_UARTE_PARITY_INCLUDED;
+            break;
+#endif
+
+        default:
+            return ARM_USART_ERROR_PARITY;
+    }
+
+    switch (control & ARM_USART_FLOW_CONTROL_Msk) {
+        case ARM_USART_FLOW_CONTROL_NONE:
+            hal_cfg.hwfc = NRF_UARTE_HWFC_DISABLED;
+            break;
+
+        case ARM_USART_FLOW_CONTROL_RTS_CTS:
+            hal_cfg.hwfc = NRF_UARTE_HWFC_ENABLED;
+            break;
+
+        default:
+            return ARM_USART_ERROR_FLOW_CONTROL;
+    }
+
+    uart_resources->baudrate = baudrate;
+    uart_resources->hal_cfg  = hal_cfg;
+
+    nrf_uarte_baudrate_set(uart_resources->uarte.p_reg,
+                           uart_resources->baudrate);
+    nrf_uarte_configure(uart_resources->uarte.p_reg,
+                        &uart_resources->hal_cfg);
+
+    return ARM_DRIVER_OK;
+}
+
+static ARM_USART_STATUS ARM_USART_GetStatus(void)
+{
+    ARM_USART_STATUS status = {0};
+    return status;
+}
+
+static int32_t ARM_USART_SetModemControl(ARM_USART_MODEM_CONTROL control)
+{
+    ARG_UNUSED(control);
+    return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static ARM_USART_MODEM_STATUS ARM_USART_GetModemStatus(void)
+{
+    ARM_USART_MODEM_STATUS status = {0};
+    return status;
+}
+
+#define DRIVER_USART(idx)                                                 \
+    static nrfx_uarte_config_t UART##idx##_initial_config = {             \
+        .pseltxd  = RTE_USART##idx##_TXD_PIN,                             \
+        .pselrxd  = RTE_USART##idx##_RXD_PIN,                             \
+        .pselrts  = RTE_USART##idx##_RTS_PIN,                             \
+        .pselcts  = RTE_USART##idx##_CTS_PIN,                             \
+        .baudrate = NRF_UARTE_BAUDRATE_115200,                            \
+        .interrupt_priority = NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY,     \
+        .hal_cfg  = {                                                     \
+            .hwfc   = NRF_UARTE_HWFC_DISABLED,                            \
+            .parity = NRF_UARTE_PARITY_EXCLUDED,                          \
+            .stop   = NRF_UARTE_STOP_ONE,                                 \
+        },                                                                \
+    };                                                                    \
+    static UARTx_Resources UART##idx##_Resources = {                      \
+        .uarte = NRFX_UARTE_INSTANCE(idx),                                \
+        .initial_config = &UART##idx##_initial_config,                    \
+    };                                                                    \
+    static int32_t ARM_USART##idx##_Initialize(                           \
+                                        ARM_USART_SignalEvent_t cb_event) \
+    {                                                                     \
+        return ARM_USARTx_Initialize(cb_event, &UART##idx##_Resources);   \
+    }                                                                     \
+    static int32_t ARM_USART##idx##_Uninitialize(void)                    \
+    {                                                                     \
+        return ARM_USARTx_Uninitialize(&UART##idx##_Resources);           \
+    }                                                                     \
+    static int32_t ARM_USART##idx##_PowerControl(ARM_POWER_STATE state)   \
+    {                                                                     \
+        return ARM_USARTx_PowerControl(state, &UART##idx##_Resources);    \
+    }                                                                     \
+    static int32_t ARM_USART##idx##_Send(const void *data, uint32_t num)  \
+    {                                                                     \
+        return ARM_USARTx_Send(data, num, &UART##idx##_Resources);        \
+    }                                                                     \
+    static int32_t ARM_USART##idx##_Receive(void *data, uint32_t num)     \
+    {                                                                     \
+        return ARM_USARTx_Receive(data, num, &UART##idx##_Resources);     \
+    }                                                                     \
+    static uint32_t ARM_USART##idx##_GetTxCount(void)                     \
+    {                                                                     \
+        return ARM_USARTx_GetTxCount(&UART##idx##_Resources);             \
+    }                                                                     \
+    static uint32_t ARM_USART##idx##_GetRxCount(void)                     \
+    {                                                                     \
+        return ARM_USARTx_GetRxCount(&UART##idx##_Resources);             \
+    }                                                                     \
+    static int32_t ARM_USART##idx##_Control(uint32_t control,             \
+                                            uint32_t arg)                 \
+    {                                                                     \
+        return ARM_USARTx_Control(control, arg, &UART##idx##_Resources);  \
+    }                                                                     \
+    ARM_DRIVER_USART Driver_USART##idx = {                                \
+        .GetVersion      = ARM_USART_GetVersion,                          \
+        .GetCapabilities = ARM_USART_GetCapabilities,                     \
+        .Initialize      = ARM_USART##idx##_Initialize,                   \
+        .Uninitialize    = ARM_USART##idx##_Uninitialize,                 \
+        .PowerControl    = ARM_USART##idx##_PowerControl,                 \
+        .Send            = ARM_USART##idx##_Send,                         \
+        .Receive         = ARM_USART##idx##_Receive,                      \
+        .Transfer        = ARM_USART_Transfer,                            \
+        .GetTxCount      = ARM_USART##idx##_GetTxCount,                   \
+        .GetRxCount      = ARM_USART##idx##_GetRxCount,                   \
+        .Control         = ARM_USART##idx##_Control,                      \
+        .GetStatus       = ARM_USART_GetStatus,                           \
+        .SetModemControl = ARM_USART_SetModemControl,                     \
+        .GetModemStatus  = ARM_USART_GetModemStatus                       \
+    }
+
+#if RTE_USART0
+DRIVER_USART(0);
+#endif
+
+#if RTE_USART1
+DRIVER_USART(1);
+#endif
+
+#if RTE_USART2
+DRIVER_USART(2);
+#endif
+
+#if RTE_USART3
+DRIVER_USART(3);
+#endif
+
+#endif /* RTE_USART0 || RTE_USART1 || RTE_USART2 || RTE_USART3 */

--- a/platform/ext/target/nordic_nrf/common/nrf_common.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf_common.cmake
@@ -119,8 +119,8 @@ elseif(BUILD_CMSIS_DRIVERS)
   message(WARNING "BUILD_CMSIS_DRIVERS not implemented.")
   #list(APPEND ALL_SRC_C_S "${NRF_COMMON_DIR}/cmsis_drivers/Driver_MPC.c"
   #  "${NRF_COMMON_DIR}/cmsis_drivers/Driver_PPC.c")
-  #list(APPEND ALL_SRC_C "${NRF_COMMON_DIR}/cmsis_drivers/Driver_USART.c")
-  #embedded_include_directories(PATH "${NRF_COMMON_DIR}/cmsis_drivers" ABSOLUTE)
+  list(APPEND ALL_SRC_C "${NRF_COMMON_DIR}/cmsis_drivers/Driver_USART.c")
+  embedded_include_directories(PATH "${NRF_COMMON_DIR}/cmsis_drivers" ABSOLUTE)
   embedded_include_directories(PATH "${PLATFORM_DIR}/driver" ABSOLUTE)
 endif()
 

--- a/platform/ext/target/nordic_nrf/common/nrfx_config.h
+++ b/platform/ext/target/nordic_nrf/common/nrfx_config.h
@@ -32,6 +32,24 @@
 #ifndef NRFX_CONFIG_H__
 #define NRFX_CONFIG_H__
 
+#include <RTE_Device.h>
+
+#if RTE_USART0 || RTE_USART1 || RTE_USART2 || RTE_USART3
+#define NRFX_UARTE_ENABLED 1
+#endif
+#if RTE_USART0
+#define NRFX_UARTE0_ENABLED 1
+#endif
+#if RTE_USART1
+#define NRFX_UARTE1_ENABLED 1
+#endif
+#if RTE_USART2
+#define NRFX_UARTE1_ENABLED 1
+#endif
+#if RTE_USART3
+#define NRFX_UARTE1_ENABLED 1
+#endif
+
 /*
  * For chips with TrustZone support, MDK provides CMSIS-Core peripheral
  * accessing symbols in two flavors, with secure and non-secure base address

--- a/platform/ext/target/nordic_nrf/common/nrfx_glue.h
+++ b/platform/ext/target/nordic_nrf/common/nrfx_glue.h
@@ -147,7 +147,7 @@ void nrfx_critical_section_exit(void);
  *
  * @param us_time Number of microseconds to wait.
  */
-#define NRFX_DELAY_US(us_time)  nrfx_coredep_us(us_time)
+#define NRFX_DELAY_US(us_time)  nrfx_coredep_delay_us(us_time)
 
 //------------------------------------------------------------------------------
 

--- a/platform/ext/target/nordic_nrf/nrf5340/RTE_Device.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/RTE_Device.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2020 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::Drivers:USART
+#define   RTE_USART0                    1
+//   <h> Pin Selection
+//     <o> TXD
+#define   RTE_USART0_TXD_PIN            20
+//     <o> RXD
+#define   RTE_USART0_RXD_PIN            22
+//     <o> RTS
+#define   RTE_USART0_RTS_PIN            19
+//     <o> CTS
+#define   RTE_USART0_CTS_PIN            21
+//   </h> Pin Configuration
+// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
+
+// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::Drivers:USART
+#define   RTE_USART1                    0
+//   <h> Pin Selection
+//     <o> TXD
+#define   RTE_USART1_TXD_PIN            0
+//     <o> RXD
+#define   RTE_USART1_RXD_PIN            0
+//     <o> RTS
+#define   RTE_USART1_RTS_PIN            0
+//     <o> CTS
+#define   RTE_USART1_CTS_PIN            0
+//   </h> Pin Configuration
+// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
+
+// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::Drivers:USART
+#define   RTE_USART2                    0
+//   <h> Pin Selection
+//     <o> TXD
+#define   RTE_USART2_TXD_PIN            0
+//     <o> RXD
+#define   RTE_USART2_RXD_PIN            0
+//     <o> RTS
+#define   RTE_USART2_RTS_PIN            0
+//     <o> CTS
+#define   RTE_USART2_CTS_PIN            0
+//   </h> Pin Configuration
+// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
+
+// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::Drivers:USART
+#define   RTE_USART3                    0
+//   <h> Pin Selection
+//     <o> TXD
+#define   RTE_USART3_TXD_PIN            0
+//     <o> RXD
+#define   RTE_USART3_RXD_PIN            0
+//     <o> RTS
+#define   RTE_USART3_RTS_PIN            0
+//     <o> CTS
+#define   RTE_USART3_RTS_PIN            0
+//   </h> Pin Configuration
+// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
+
+#endif  /* __RTE_DEVICE_H */

--- a/platform/ext/target/nordic_nrf/nrf9160/RTE_Device.h
+++ b/platform/ext/target/nordic_nrf/nrf9160/RTE_Device.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 Arm Limited. All rights reserved.
+ * Copyright (c) 2020 Nordic Semiconductor ASA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::Drivers:USART
+#define   RTE_USART0                    1
+//   <h> Pin Selection
+//     <o> TXD
+#define   RTE_USART0_TXD_PIN            29
+//     <o> RXD
+#define   RTE_USART0_RXD_PIN            28
+//     <o> RTS
+#define   RTE_USART0_RTS_PIN            27
+//     <o> CTS
+#define   RTE_USART0_CTS_PIN            26
+//   </h> Pin Configuration
+// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
+
+// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::Drivers:USART
+#define   RTE_USART1                    0
+//   <h> Pin Selection
+//     <o> TXD
+#define   RTE_USART1_TXD_PIN            0
+//     <o> RXD
+#define   RTE_USART1_RXD_PIN            0
+//     <o> RTS
+#define   RTE_USART1_RTS_PIN            0
+//     <o> CTS
+#define   RTE_USART1_CTS_PIN            0
+//   </h> Pin Configuration
+// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
+
+// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::Drivers:USART
+#define   RTE_USART2                    0
+//   <h> Pin Selection
+//     <o> TXD
+#define   RTE_USART2_TXD_PIN            0
+//     <o> RXD
+#define   RTE_USART2_RXD_PIN            0
+//     <o> RTS
+#define   RTE_USART2_RTS_PIN            0
+//     <o> CTS
+#define   RTE_USART2_CTS_PIN            0
+//   </h> Pin Configuration
+// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
+
+// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::Drivers:USART
+#define   RTE_USART3                    0
+//   <h> Pin Selection
+//     <o> TXD
+#define   RTE_USART3_TXD_PIN            0
+//     <o> RXD
+#define   RTE_USART3_RXD_PIN            0
+//     <o> RTS
+#define   RTE_USART3_RTS_PIN            0
+//     <o> CTS
+#define   RTE_USART3_RTS_PIN            0
+//   </h> Pin Configuration
+// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
+
+#endif  /* __RTE_DEVICE_H */


### PR DESCRIPTION
Add an implementation of the CMSIS USART driver API that uses
the nrfx_uarte driver underneath. Plus corresponding configuration
files for nRF5340 and nRF9160, and related translation layer that
activates relevant parts of nrfx.