### PR TITLE
Tfm platform cfg peripherals (nrf5340)

### DIFF
--- a/platform/ext/target/nordic_nrf/common/native_drivers/spu.c
+++ b/platform/ext/target/nordic_nrf/common/native_drivers/spu.c
@@ -151,3 +151,37 @@ void spu_regions_flash_config_non_secure_callable(uint32_t start_addr,
 		FLASH_NSC_REGION_FROM_ADDR(start_addr),
 		1 /* Lock */);
 }
+
+void spu_peripheral_config_secure(uint32_t periph_base_addr, bool periph_lock)
+{
+	/* Determine peripheral ID */
+	const uint8_t periph_id = NRFX_PERIPHERAL_ID_GET(periph_base_addr);
+
+	/* ASSERT checking that this is not an explicit Non-Secure peripheral */
+	NRFX_ASSERT((NRF_SPU->PERIPHID[periph_id].PERM &
+		SPU_PERIPHID_PERM_SECUREMAPPING_Msk) !=
+		(SPU_PERIPHID_PERM_SECUREMAPPING_NonSecure <<
+			SPU_PERIPHID_PERM_SECUREMAPPING_Pos));
+
+	nrf_spu_peripheral_set(NRF_SPU, periph_id,
+		1 /* Secure */,
+		1 /* Secure DMA */,
+		periph_lock);
+}
+
+void spu_peripheral_config_non_secure(uint32_t periph_base_addr, bool periph_lock)
+{
+	/* Determine peripheral ID */
+	const uint8_t periph_id = NRFX_PERIPHERAL_ID_GET(periph_base_addr);
+
+	/* ASSERT checking that this is not an explicit Secure peripheral */
+	NRFX_ASSERT((NRF_SPU->PERIPHID[periph_id].PERM &
+		SPU_PERIPHID_PERM_SECUREMAPPING_Msk) !=
+		(SPU_PERIPHID_PERM_SECUREMAPPING_Secure <<
+			SPU_PERIPHID_PERM_SECUREMAPPING_Pos));
+
+	nrf_spu_peripheral_set(NRF_SPU, periph_id,
+		0 /* Non-Secure */,
+		0 /* Non-Secure DMA */,
+		periph_lock);
+}

--- a/platform/ext/target/nordic_nrf/common/native_drivers/spu.h
+++ b/platform/ext/target/nordic_nrf/common/native_drivers/spu.h
@@ -77,4 +77,58 @@ void spu_regions_sram_config_non_secure( uint32_t start_addr, uint32_t limit_add
  */
 void spu_regions_flash_config_non_secure_callable(uint32_t start_addr, uint32_t limit_addr);
 
+/**
+ * \brief Restrict access to peripheral to secure
+ *
+ *  Configure a device peripheral to be accessible from Secure domain only.
+ *
+ * \param periph_base_addr peripheral base address
+ *                         (must correspond to a valid peripheral ID)
+ * \param periph_lock Variable indicating whether to lock peripheral security
+ *
+ * \note
+ * - peripheral shall not be a Non-Secure only peripheral
+ * - DMA transactions are configured as Secure
+ */
+void spu_peripheral_config_secure(uint32_t periph_base_addr, bool periph_lock);
+
+/**
+ * Configure a device peripheral to be accessible from Non-Secure domain.
+ *
+ * \param periph_base_addr peripheral base address
+ *                         (must correspond to a valid peripheral ID)
+ * \param periph_lock Variable indicating whether to lock peripheral security
+ *
+ * \note
+ * - peripheral shall not be a Secure-only peripheral
+ * - DMA transactions are configured as Non-Secure
+ */
+void spu_peripheral_config_non_secure(u32_t periph_base_addr, bool periph_lock);
+
+/**
+ * Configure DPPI channels to be accessible from Non-Secure domain.
+ *
+ * \param dppi_lock Variable indicating whether to lock DPPI channel security
+ *
+ * \note all channels are configured as Non-Secure
+ */
+static inline void spu_dppi_config_non_secure(bool dppi_lock)
+{
+    nrf_spu_dppi_config_set(NRF_SPU, 0, 0x0, dppi_lock);
+}
+
+/**
+ * Configure GPIO pins to be accessible from Non-Secure domain.
+ *
+ * \param port_number GPIO Port number
+ * \param gpio_lock Variable indicating whether to lock GPIO port security
+ *
+ * \note all pins are configured as Non-Secure
+ */
+static inline void spu_gpio_config_non_secure(uint8_t port_number,
+    bool gpio_lock)
+{
+    nrf_spu_gpio_config_set(NRF_SPU, port_number, 0x0, gpio_lock);
+}
+
 #endif

--- a/platform/ext/target/nordic_nrf/nrf5340/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/nrf5340/target_cfg.c
@@ -193,3 +193,58 @@ int32_t spu_init_cfg(void)
     return ARM_DRIVER_OK;
 }
 
+int32_t spu_periph_init_cfg(void)
+{
+	/* Peripheral configuration */
+	spu_peripheral_config_non_secure((u32_t)NRF_FPU, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_OSCILLATORS, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_RESET, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_SPIM0, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_SPIM1, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_SPIM4, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_SAADC, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_TIMER0, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_TIMER1, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_TIMER2, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_RTC0, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_RTC1, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_WDT0, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_COMP, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_EGU0, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_EGU1, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_EGU2, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_EGU3, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_EGU4, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_EGU5, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_PWM0, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_PWM1, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_PWM2, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_PDM0, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_I2S0, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_IPC, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_QSPI, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_NFCT, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_GPIOTE1_NS, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_MUTEX, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_P0, false);
+	spu_peripheral_config_non_secure((u32_t)NRF_VMC, false);
+
+	/* DPPI channel configuration */
+	spu_dppi_config_non_secure(false);
+
+	/* GPIO pin configuration (P0 and P1 ports) */
+	spu_gpio_config_non_secure(0, false);
+	spu_gpio_config_non_secure(1, false);
+
+	return ARM_DRIVER_OK;
+}
+
+void spu_periph_configure_to_secure(uint32_t periph_num)
+{
+    spu_peripheral_config_secure(periph_num, true);
+}
+
+void spu_periph_configure_to_non_secure(uint32_t periph_num)
+{
+    spu_peripheral_config_non_secure(periph_num, true);
+}

--- a/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
@@ -39,11 +39,33 @@ struct memory_region_limits {
 };
 
 /**
- * \brief Configures the Security Protection Unit.
+ * \brief Configures memory permissions via the System Protection Unit.
  *
  * \return  Returns error code.
  */
 int32_t spu_init_cfg(void);
+
+/**
+ * \brief Configures peripheral permissions via the System Protection Unit.
+ *
+ * The function does the following:
+ * - grants Non-Secure access to nRF peripherals that are not Secure-only
+ * - grants Non-Secure access to DDPI channels
+ * - grants Non-Secure access to GPIO pins
+ *
+ * \return  Returns error code.
+ */
+int32_t spu_periph_init_cfg(void);
+
+/**
+ * \brief Restrict access to peripheral to secure
+ */
+void spu_periph_configure_to_secure(uint32_t periph_num);
+
+/**
+ * \brief Allow non-secure access to peripheral
+ */
+void spu_periph_configure_to_non_secure(uint32_t periph_num);
 
 /**
  * \brief Clears SPU interrupt.


### PR DESCRIPTION
This pull request is now ready for review, after merging #5 .
The PR does the following
- defines and implements the SPM HAL API for configuring peripheral security attribution (`platform_cfg.h` and `platform_cfg.c`)
the following API is implemented
  - initial PERIPHERAL configuration (resetting all peripherals to NS, same for GPIOS and DPPIC)
  - APIs to set a specific peripheral to Secure or Non-Secure

Unlike the other ARM vendor platforms, we cannot support APIs for setting privilege/non-privilege modes on peripheral address spaces via SPU.

The commit implements also an internal SPU "driver" API to support the target_cfg requirements.
