### PR TITLE
platform: nrfx_config: Correct indexes of enabled UARTE instances

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrfx_config.h
+++ b/platform/ext/target/nordic_nrf/common/nrfx_config.h
@@ -44,10 +44,10 @@
 #define NRFX_UARTE1_ENABLED 1
 #endif
 #if RTE_USART2
-#define NRFX_UARTE1_ENABLED 1
+#define NRFX_UARTE2_ENABLED 1
 #endif
 #if RTE_USART3
-#define NRFX_UARTE1_ENABLED 1
+#define NRFX_UARTE3_ENABLED 1
 #endif
 
 /*


### PR DESCRIPTION
Correct a few copy-paste errors in nrfx_config.h.
This is a follow-up to commit 38f8a36bf22b4915283ee7a46f096a4d79bc5c36.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>