### PR TITLE
Remove unneeded #include

### DIFF
--- a/test/suites/core/non_secure/core_ns_positive_testsuite.c
+++ b/test/suites/core/non_secure/core_ns_positive_testsuite.c
@@ -20,7 +20,6 @@
 #include "tfm_veneers.h"
 #endif /* TFM_PSA_API */
 #ifdef TFM_ENABLE_IRQ_TEST
-#include "platform_irq.h"
 #include "tfm_peripherals_def.h"
 #endif
 


### PR DESCRIPTION
We don't have that file - it's a platform-internal file.

This fix is needed for certain configurations.