### PR TITLE
platform: nordic nrf: nrf_spu.h inclusion fixes

### DIFF
--- a/platform/ext/target/nordic_nrf/common/native_drivers/spu.c
+++ b/platform/ext/target/nordic_nrf/common/native_drivers/spu.c
@@ -15,7 +15,6 @@
  */
 
 #include "spu.h"
-#include <hal/nrf_spu.h>
 #include "region_defs.h"
 
 /* Platform-specific configuration */

--- a/platform/ext/target/nordic_nrf/common/native_drivers/spu.h
+++ b/platform/ext/target/nordic_nrf/common/native_drivers/spu.h
@@ -21,6 +21,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <hal/nrf_spu.h>
+
+
 /**
  * \brief SPU interrupt enabling
  *
@@ -103,7 +106,7 @@ void spu_peripheral_config_secure(uint32_t periph_base_addr, bool periph_lock);
  * - peripheral shall not be a Secure-only peripheral
  * - DMA transactions are configured as Non-Secure
  */
-void spu_peripheral_config_non_secure(u32_t periph_base_addr, bool periph_lock);
+void spu_peripheral_config_non_secure(uint32_t periph_base_addr, bool periph_lock);
 
 /**
  * Configure DPPI channels to be accessible from Non-Secure domain.

--- a/platform/ext/target/nordic_nrf/common/nrf_common.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf_common.cmake
@@ -68,7 +68,7 @@ elseif(BUILD_NATIVE_DRIVERS)
   list(APPEND ALL_SRC_C "${NRFX_DIR}/drivers/src/nrfx_uarte.c"
                         "${NRFX_DIR}/drivers/src/nrfx_nvmc.c"
                         "${NRF_COMMON_DIR}/nrfx_glue.c"
-                        #"${NRF_COMMON_DIR}/native_drivers/spu.c"
+                        "${NRF_COMMON_DIR}/native_drivers/spu.c"
                         )
 endif()
 


### PR DESCRIPTION
Move the inclusion of nrf_spu.h from spu.c to spu.h
since we have inline functions depending on nrfx there.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>