### PR TITLE
platform: nrfx_glue: Use assert() to implement NRFX_ASSERT()

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrfx_glue.h
+++ b/platform/ext/target/nordic_nrf/common/nrfx_glue.h
@@ -32,7 +32,7 @@
 #ifndef NRFX_GLUE_H__
 #define NRFX_GLUE_H__
 
-#include <log/tfm_assert.h>
+#include <assert.h>
 
 #include <soc/nrfx_atomic.h>
 #include <soc/nrfx_coredep.h>
@@ -58,7 +58,7 @@ extern "C" {
  *
  * @param expression Expression to be evaluated.
  */
-#define NRFX_ASSERT(expression)  TFM_ASSERT(expression)
+#define NRFX_ASSERT(expression)  assert(expression)
 
 /**
  * @brief Macro for placing a compile time assertion.


### PR DESCRIPTION
assert() is used in the source tree much wider than TFM_ASSERT(),
so it seems to be a better fit for implementation of NRFX_ASSERT().
Furthermore, TFM_ASSERT() calls tfm_log_printf(), which is not
available in BL2, where we also need nrfx drivers (underneath
the CMSIS ones) and thus we need proper NRFX_ASSERT() there.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>