### PR TITLE
platform: nordic_nrf: flash_layout: remove macros for non-BL2 builds

### DIFF
--- a/platform/ext/target/nordic_nrf/nrf5340/partition/flash_layout.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/partition/flash_layout.h
@@ -67,7 +67,7 @@
 /* Flash layout info for BL2 bootloader */
 #define FLASH_BASE_ADDRESS                  (0x00000000)
 
-#ifdef BL2
+
 /* Offset and size definitions of the flash partitions that are handled by the
  * bootloader. The image swapping is done between IMAGE_PRIMARY and
  * IMAGE_SECONDARY, SCRATCH is used as a temporary storage during image
@@ -133,15 +133,6 @@
  */
 #define MCUBOOT_STATUS_MAX_ENTRIES      (0)
 
-#else
-
-/* Secure + Non-secure image primary slot */
-#define FLASH_AREA_0_ID            (1)
-#define FLASH_AREA_0_OFFSET        (0x0)
-#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE + \
-                                    FLASH_NS_PARTITION_SIZE)
-
-#endif /* BL2 */
 
 #define FLASH_SST_AREA_OFFSET           (FLASH_AREA_SCRATCH_OFFSET + \
                                          FLASH_AREA_SCRATCH_SIZE)

--- a/platform/ext/target/nordic_nrf/nrf9160/partition/flash_layout.h
+++ b/platform/ext/target/nordic_nrf/nrf9160/partition/flash_layout.h
@@ -67,7 +67,7 @@
 /* Flash layout info for BL2 bootloader */
 #define FLASH_BASE_ADDRESS                  (0x00000000)
 
-#ifdef BL2
+
 /* Offset and size definitions of the flash partitions that are handled by the
  * bootloader. The image swapping is done between IMAGE_PRIMARY and
  * IMAGE_SECONDARY, SCRATCH is used as a temporary storage during image
@@ -133,15 +133,6 @@
  */
 #define MCUBOOT_STATUS_MAX_ENTRIES      (0)
 
-#else
-
-/* Secure + Non-secure image primary slot */
-#define FLASH_AREA_0_ID            (1)
-#define FLASH_AREA_0_OFFSET        (0x0)
-#define FLASH_AREA_0_SIZE          (FLASH_S_PARTITION_SIZE + \
-                                    FLASH_NS_PARTITION_SIZE)
-
-#endif /* BL2 */
 
 #define FLASH_SST_AREA_OFFSET           (FLASH_AREA_SCRATCH_OFFSET + \
                                          FLASH_AREA_SCRATCH_SIZE)


### PR DESCRIPTION
It turns out that we do not need the FLASH_AREA_0_
macro definitions for TF-M builds without BL2. These
macros are not used, they are not present in most of
the other platform targets.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>