### PR TITLE
platform: nordic_nrf: Add VTOR initialization in secure startup code

### DIFF
--- a/platform/ext/target/nordic_nrf/nrf5340/gcc/startup_nrf5340_s.S
+++ b/platform/ext/target/nordic_nrf/nrf5340/gcc/startup_nrf5340_s.S
@@ -244,6 +244,12 @@ Reset_Handler:
 #endif /* __STARTUP_CLEAR_BSS_MULTIPLE || __STARTUP_CLEAR_BSS */
 
     cpsid   i              /* Disable IRQs */
+
+/* Setup Vector Table Offset Register. */
+    ldr     r0, =__Vectors
+    ldr     r1, =0xE000ED08 /* SCB->VTOR */
+    str     r0, [r1]
+
     bl      SystemInit
 
     mrs     r0, control    /* Get control value */

--- a/platform/ext/target/nordic_nrf/nrf9160/gcc/startup_nrf9160_s.S
+++ b/platform/ext/target/nordic_nrf/nrf9160/gcc/startup_nrf9160_s.S
@@ -240,6 +240,12 @@ Reset_Handler:
 #endif /* __STARTUP_CLEAR_BSS_MULTIPLE || __STARTUP_CLEAR_BSS */
 
     cpsid   i              /* Disable IRQs */
+
+/* Setup Vector Table Offset Register. */
+    ldr     r0, =__Vectors
+    ldr     r1, =0xE000ED08 /* SCB->VTOR */
+    str     r0, [r1]
+
     bl      SystemInit
 
     mrs     r0, control    /* Get control value */


### PR DESCRIPTION
Add initialization of SCB->VTOR in the startup code for secure images
on nRF5340 and nRF9160. Other platforms do this at the beginning of
SystemInit(), but since nRF targets use the implementation of this
function from MDK, it cannot be done exactly the same way.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>