### PR TITLE
platform: nrf5340: spm_hal: configure peripheral default isolation

### DIFF
--- a/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
@@ -39,6 +39,15 @@ struct memory_region_limits {
 };
 
 /**
+ * \brief Holds the data necessary to do isolation for a specific peripheral.
+ */
+struct tfm_spm_partition_platform_data_t
+{
+    uint32_t periph_start;
+    uint32_t periph_limit;
+};
+
+/**
  * \brief Configures memory permissions via the System Protection Unit.
  *
  * \return  Returns error code.


### PR DESCRIPTION
We implement the function to configure peripheral isolation
for peripherals belonging to (Secure) partitions. We implement
the MPU configuration, allowing the peripheral to be accessed
by non-privileged code, and configure the SPU, setting the
peripheral to be accessible by Secure domain only.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>


Notes
- the function is supposed to implement isolation for peripherals belonging to secure partitions.

- the function uses the MPU configuration on peripheral space, similar to what the other targets are doing. This is done so as to be able to use a peripheral from nPRIV code
- in addition, the function configures a peripheral in this list to Secure. Note that SPU cannot assign PRIV/nPRIV attribution configuration, so inevitably this function only adds Secure configuration.

