### PR TITLE
platform: nrf5340: Enable UARTE1 and use it as TFM_DRIVER_STDIO

### DIFF
--- a/platform/ext/target/nordic_nrf/boards/nrf5340pdk_nrf5340_cpuapp/RTE_Device.h
+++ b/platform/ext/target/nordic_nrf/boards/nrf5340pdk_nrf5340_cpuapp/RTE_Device.h
@@ -23,7 +23,7 @@
 // <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
 // <i> Configuration settings for Driver_USART0 in component ::Drivers:USART
 #define   RTE_USART0                    1
-//   <h> Pin Selection
+//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
 //     <o> TXD
 #define   RTE_USART0_TXD_PIN            20
 //     <o> RXD
@@ -37,46 +37,46 @@
 
 // <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
 // <i> Configuration settings for Driver_USART1 in component ::Drivers:USART
-#define   RTE_USART1                    0
-//   <h> Pin Selection
+#define   RTE_USART1                    1
+//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
 //     <o> TXD
-#define   RTE_USART1_TXD_PIN            0
+#define   RTE_USART1_TXD_PIN            25
 //     <o> RXD
-#define   RTE_USART1_RXD_PIN            0
+#define   RTE_USART1_RXD_PIN            26
 //     <o> RTS
-#define   RTE_USART1_RTS_PIN            0
+#define   RTE_USART1_RTS_PIN            0xFFFFFFFF
 //     <o> CTS
-#define   RTE_USART1_CTS_PIN            0
+#define   RTE_USART1_CTS_PIN            0xFFFFFFFF
 //   </h> Pin Configuration
 // </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
 
 // <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
 // <i> Configuration settings for Driver_USART2 in component ::Drivers:USART
 #define   RTE_USART2                    0
-//   <h> Pin Selection
+//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
 //     <o> TXD
-#define   RTE_USART2_TXD_PIN            0
+#define   RTE_USART2_TXD_PIN            0xFFFFFFFF
 //     <o> RXD
-#define   RTE_USART2_RXD_PIN            0
+#define   RTE_USART2_RXD_PIN            0xFFFFFFFF
 //     <o> RTS
-#define   RTE_USART2_RTS_PIN            0
+#define   RTE_USART2_RTS_PIN            0xFFFFFFFF
 //     <o> CTS
-#define   RTE_USART2_CTS_PIN            0
+#define   RTE_USART2_CTS_PIN            0xFFFFFFFF
 //   </h> Pin Configuration
 // </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
 
 // <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
 // <i> Configuration settings for Driver_USART3 in component ::Drivers:USART
 #define   RTE_USART3                    0
-//   <h> Pin Selection
+//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
 //     <o> TXD
-#define   RTE_USART3_TXD_PIN            0
+#define   RTE_USART3_TXD_PIN            0xFFFFFFFF
 //     <o> RXD
-#define   RTE_USART3_RXD_PIN            0
+#define   RTE_USART3_RXD_PIN            0xFFFFFFFF
 //     <o> RTS
-#define   RTE_USART3_RTS_PIN            0
+#define   RTE_USART3_RTS_PIN            0xFFFFFFFF
 //     <o> CTS
-#define   RTE_USART3_RTS_PIN            0
+#define   RTE_USART3_RTS_PIN            0xFFFFFFFF
 //   </h> Pin Configuration
 // </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
 

--- a/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf5340/target_cfg.h
@@ -20,7 +20,7 @@
 
 #include "tfm_plat_defs.h"
 
-#define TFM_DRIVER_STDIO    Driver_USART0
+#define TFM_DRIVER_STDIO    Driver_USART1
 #define NS_DRIVER_STDIO     Driver_USART0
 
 /**


### PR DESCRIPTION
Enable Driver_USART1 that uses UARTE1 and pins P0.25/P0.26 for TX/RX,
and map it to TFM_DRIVER_STDIO so that it becomes the standard input
and output device for TFM.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>