### PR TITLE
platform: nordic_nrf: Import patch for nrfx_nvmc.c from nrfx repository (2)

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrfx/drivers/src/nrfx_nvmc.c
+++ b/platform/ext/target/nordic_nrf/common/nrfx/drivers/src/nrfx_nvmc.c
@@ -189,27 +189,42 @@ static uint32_t partial_word_create(uint32_t addr, uint8_t const * bytes, uint32
 
 static void nvmc_readonly_mode_set(void)
 {
-#if defined(NRF_TRUSTZONE_NONSECURE)
+    /*
+     * For secure code, the access mode needs to be set for both secure and
+     * non-secure regions.
+     */
+#if defined(NVMC_CONFIGNS_WEN_Msk)
     nrf_nvmc_nonsecure_mode_set(NRF_NVMC, NRF_NVMC_NS_MODE_READONLY);
-#else
+#endif
+#if !defined(NRF_TRUSTZONE_NONSECURE)
     nrf_nvmc_mode_set(NRF_NVMC, NRF_NVMC_MODE_READONLY);
 #endif
 }
 
 static void nvmc_write_mode_set(void)
 {
-#if defined(NRF_TRUSTZONE_NONSECURE)
+    /*
+     * For secure code, the access mode needs to be set for both secure and
+     * non-secure regions.
+     */
+#if defined(NVMC_CONFIGNS_WEN_Msk)
     nrf_nvmc_nonsecure_mode_set(NRF_NVMC, NRF_NVMC_NS_MODE_WRITE);
-#else
+#endif
+#if !defined(NRF_TRUSTZONE_NONSECURE)
     nrf_nvmc_mode_set(NRF_NVMC, NRF_NVMC_MODE_WRITE);
 #endif
 }
 
 static void nvmc_erase_mode_set(void)
 {
-#if defined(NRF_TRUSTZONE_NONSECURE)
+    /*
+     * For secure code, the access mode needs to be set for both secure and
+     * non-secure regions.
+     */
+#if defined(NVMC_CONFIGNS_WEN_Msk)
     nrf_nvmc_nonsecure_mode_set(NRF_NVMC, NRF_NVMC_NS_MODE_ERASE);
-#else
+#endif
+#if !defined(NRF_TRUSTZONE_NONSECURE)
     nrf_nvmc_mode_set(NRF_NVMC, NRF_NVMC_MODE_ERASE);
 #endif
 }


### PR DESCRIPTION
This imports commit 233c96307e0946fc44035424c410bd44ddf2d75e from
the nrfx repository at https://github.com/NordicSemiconductor/nrfx,
which introduces the following change:

nrfx_nvmc: Fix setting of program memory access mode for secure code

For secure code, the access mode needs to be set for both secure and
non-secure regions. Otherwise, attempts from secure code to write or
erase a region configured as non-secure end up with BusFault.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>