### PR TITLE
platform: nordic_nrf: Prevent transfers on uninitialized UART

### DIFF
--- a/platform/ext/target/nordic_nrf/common/cmsis_drivers/Driver_USART.c
+++ b/platform/ext/target/nordic_nrf/common/cmsis_drivers/Driver_USART.c
@@ -45,6 +45,7 @@ typedef struct {
     size_t               rx_count;
     nrf_uarte_config_t   hal_cfg;
     nrf_uarte_baudrate_t baudrate;
+    bool                 initialized;
 } UARTx_Resources;
 
 static ARM_DRIVER_VERSION ARM_USART_GetVersion(void)
@@ -73,12 +74,16 @@ static int32_t ARM_USARTx_Initialize(ARM_USART_SignalEvent_t cb_event,
     uart_resources->rx_count = 0;
     uart_resources->hal_cfg  = uart_resources->initial_config->hal_cfg;
     uart_resources->baudrate = uart_resources->initial_config->baudrate;
+
+    uart_resources->initialized = true;
     return ARM_DRIVER_OK;
 }
 
 static int32_t ARM_USARTx_Uninitialize(UARTx_Resources *uart_resources)
 {
     nrfx_uarte_uninit(&uart_resources->uarte);
+
+    uart_resources->initialized = false;
     return ARM_DRIVER_OK;
 }
 
@@ -102,6 +107,10 @@ static int32_t ARM_USARTx_PowerControl(ARM_POWER_STATE state,
 static int32_t ARM_USARTx_Send(const void *data, uint32_t num,
                                UARTx_Resources *uart_resources)
 {
+    if (!uart_resources->initialized) {
+        return ARM_DRIVER_ERROR;
+    }
+
     nrfx_err_t err_code = nrfx_uarte_tx(&uart_resources->uarte, data, num);
     if (err_code == NRFX_ERROR_BUSY) {
         return ARM_DRIVER_ERROR_BUSY;
@@ -116,6 +125,10 @@ static int32_t ARM_USARTx_Send(const void *data, uint32_t num,
 static int32_t ARM_USARTx_Receive(void *data, uint32_t num,
                                   UARTx_Resources *uart_resources)
 {
+    if (!uart_resources->initialized) {
+        return ARM_DRIVER_ERROR;
+    }
+
     nrfx_err_t err_code = nrfx_uarte_rx(&uart_resources->uarte, data, num);
     if (err_code == NRFX_ERROR_BUSY) {
         return ARM_DRIVER_ERROR_BUSY;


### PR DESCRIPTION
Return an error if a transfer is attempted on a UART that has not been
initialized yet. Such attempt can occur when for instance an assertion
fails before the stdio UART is initialized. Since the nrfx_uarte driver
uses also an assertion for checking if it has been initialized prior to
starting a transfer, the CMSIS driver must prevent such attempts.
Otherwise, such situation would lead to a stack overflow and HardFault.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>