### PR TITLE
Fixes needed for RegressionIPC configuration

### DIFF
--- a/platform/ext/common/gcc/tfm_common_s.ld
+++ b/platform/ext/common/gcc/tfm_common_s.ld
@@ -602,6 +602,29 @@ SECTIONS
 
 #endif /* TFM_LVL != 1 */
 
+    .ER_TFM_CODE : ALIGN(4)
+    {
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+         *crtbegin.o(.dtors)
+         *crtbegin?.o(.dtors)
+         *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+         *(SORT(.dtors.*))
+         *(.dtors)
+    } > FLASH
+
 #ifndef TFM_MULTI_CORE_TOPOLOGY
     /*
      * Place the CMSE Veneers (containing the SG instructions) in a correctly
@@ -640,28 +663,8 @@ SECTIONS
             <= CMSE_VENEER_REGION_SIZE, "Veneer region overflowed")
 #endif
 
-    .ER_TFM_CODE : ALIGN(4)
+    .tfm_rodata : ALIGN(4)
     {
-        *(.text*)
-
-        KEEP(*(.init))
-        KEEP(*(.fini))
-
-
-        /* .ctors */
-        *crtbegin.o(.ctors)
-        *crtbegin?.o(.ctors)
-        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
-        *(SORT(.ctors.*))
-        *(.ctors)
-
-        /* .dtors */
-         *crtbegin.o(.dtors)
-         *crtbegin?.o(.dtors)
-         *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
-         *(SORT(.dtors.*))
-         *(.dtors)
-
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/platform/ext/common/gcc/tfm_common_s.ld.template
+++ b/platform/ext/common/gcc/tfm_common_s.ld.template
@@ -266,6 +266,29 @@ SECTIONS
 
 #endif /* TFM_LVL != 1 */
 
+    .ER_TFM_CODE : ALIGN(4)
+    {
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+         *crtbegin.o(.dtors)
+         *crtbegin?.o(.dtors)
+         *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+         *(SORT(.dtors.*))
+         *(.dtors)
+    } > FLASH
+
 #ifndef TFM_MULTI_CORE_TOPOLOGY
     /*
      * Place the CMSE Veneers (containing the SG instructions) in a correctly
@@ -304,28 +327,8 @@ SECTIONS
             <= CMSE_VENEER_REGION_SIZE, "Veneer region overflowed")
 #endif
 
-    .ER_TFM_CODE : ALIGN(4)
+    .tfm_rodata : ALIGN(4)
     {
-        *(.text*)
-
-        KEEP(*(.init))
-        KEEP(*(.fini))
-
-
-        /* .ctors */
-        *crtbegin.o(.ctors)
-        *crtbegin?.o(.ctors)
-        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
-        *(SORT(.ctors.*))
-        *(.ctors)
-
-        /* .dtors */
-         *crtbegin.o(.dtors)
-         *crtbegin?.o(.dtors)
-         *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
-         *(SORT(.dtors.*))
-         *(.dtors)
-
         *(.rodata*)
 
         KEEP(*(.eh_frame*))

--- a/platform/ext/target/nordic_nrf/nrf9160/partition/region_defs.h
+++ b/platform/ext/target/nordic_nrf/nrf9160/partition/region_defs.h
@@ -104,7 +104,7 @@
 #define S_CODE_LIMIT    (S_CODE_START + S_CODE_SIZE - 1)
 
 #define S_DATA_START    (S_RAM_ALIAS(0x0))
-#define S_DATA_SIZE     (TOTAL_RAM_SIZE / 4) /* 64 KB */
+#define S_DATA_SIZE     ((TOTAL_RAM_SIZE / 2) - 0x4000) /* 112 KB */
 #define S_DATA_LIMIT    (S_DATA_START + S_DATA_SIZE - 1)
 
 /* The CMSE veneers shall be placed in an NSC region
@@ -127,8 +127,8 @@
 #define NS_CODE_SIZE    (IMAGE_NS_CODE_SIZE)
 #define NS_CODE_LIMIT   (NS_CODE_START + NS_CODE_SIZE - 1)
 
-#define NS_DATA_START   (NS_RAM_ALIAS(TOTAL_RAM_SIZE / 2)) /* 64 KB are reserved for shared RAM */
-#define NS_DATA_SIZE    (TOTAL_RAM_SIZE / 2) /* 128 KB */
+#define NS_DATA_START   (NS_RAM_ALIAS(TOTAL_RAM_SIZE / 2) + 0xC000) /* 64 KB are reserved for shared RAM */
+#define NS_DATA_SIZE    ((TOTAL_RAM_SIZE / 2) - 0xC000) /* 80 KB */
 #define NS_DATA_LIMIT   (NS_DATA_START + NS_DATA_SIZE - 1)
 
 /* NS partition information is used for SPU configuration */


### PR DESCRIPTION
Zephyr [tfm_integration samples](https://github.com/zephyrproject-rtos/zephyr/tree/master/samples/tfm_integration) use RegressionIPC configuration for building TF-M.

With the changes contained in this PR it is possible to successfully build and run those samples on both nRF5340 and nRF9160.
In order to use this branch in Zephyr, in place of its [fork of TF-M](https://github.com/zephyrproject-rtos/trusted-firmware-m/tree/master/trusted-firmware-m), some more adaptations from its trusted-firmware-m module need to be applied, see https://github.com/anangl/trusted-firmware-m/commit/c761f2efffba3bee6eb4d4a4aa786188d18f5926.

And finally, the following changes in Zephyr's board definitions are needed for building and running the tfm_integration samples with TF-M from this PR:
- [nrf5340pdk_nrf5340](https://github.com/anangl/zephyr/commit/c82e113d1e797b9c01e52bd157ca2085721536be)
- [nrf9160dk_nrf9160](https://github.com/anangl/zephyr/commit/19dba803664201b0bb2c76aef7a88b93cbe4eb63)