### PR TITLE
platform: nordic_nrf: Correct names of Non-Secure TIMER handlers

### DIFF
--- a/platform/ext/target/nordic_nrf/nrf5340/gcc/startup_nrf5340_ns.S
+++ b/platform/ext/target/nordic_nrf/nrf5340/gcc/startup_nrf5340_ns.S
@@ -63,7 +63,7 @@ __Vectors:
     .long   0                           /* Reserved */
     .long   SAADC_IRQHandler
     .long   TIMER0_IRQHandler
-    .long   TIMER1_IRQHandler
+    .long   TIMER1_Handler
     .long   TIMER2_IRQHandler
     .long   0                           /* Reserved */
     .long   0                           /* Reserved */
@@ -295,7 +295,7 @@ Default_Handler:
     def_irq_handler      SPIM3_SPIS3_TWIM3_TWIS3_UARTE3_IRQHandler
     def_irq_handler      SAADC_IRQHandler
     def_irq_handler      TIMER0_IRQHandler
-    def_irq_handler      TIMER1_IRQHandler
+    def_irq_handler      TIMER1_Handler
     def_irq_handler      TIMER2_IRQHandler
     def_irq_handler      RTC0_IRQHandler
     def_irq_handler      RTC1_IRQHandler

--- a/platform/ext/target/nordic_nrf/nrf9160/gcc/startup_nrf9160_ns.S
+++ b/platform/ext/target/nordic_nrf/nrf9160/gcc/startup_nrf9160_ns.S
@@ -63,7 +63,7 @@ __Vectors:
     .long   0                           /* Reserved */
     .long   SAADC_IRQHandler
     .long   TIMER0_IRQHandler
-    .long   TIMER1_IRQHandler
+    .long   TIMER1_Handler
     .long   TIMER2_IRQHandler
     .long   0                           /* Reserved */
     .long   0                           /* Reserved */
@@ -289,7 +289,7 @@ Default_Handler:
     def_irq_handler      UARTE3_SPIM3_SPIS3_TWIM3_TWIS3_IRQHandler
     def_irq_handler      SAADC_IRQHandler
     def_irq_handler      TIMER0_IRQHandler
-    def_irq_handler      TIMER1_IRQHandler
+    def_irq_handler      TIMER1_Handler
     def_irq_handler      TIMER2_IRQHandler
     def_irq_handler      RTC0_IRQHandler
     def_irq_handler      RTC1_IRQHandler


### PR DESCRIPTION
Those are supposed to be TIMER1_Handler, not TIMER1_IRQHandler
(see [core_ns_positive_testsuite.c](https://github.com/NordicPlayground/trusted-firmware-m/blob/master/test/suites/core/non_secure/core_ns_positive_testsuite.c#L492)).

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>