### PR TITLE
tfm core: make has_access_to_region() compatible with vendor IDAUs

### DIFF
--- a/platform/ext/target/nordic_nrf/common/native_drivers/spu.c
+++ b/platform/ext/target/nordic_nrf/common/native_drivers/spu.c
@@ -21,6 +21,9 @@
 #define FLASH_SECURE_ATTRIBUTION_REGION_SIZE SPU_FLASH_REGION_SIZE
 #define SRAM_SECURE_ATTRIBUTION_REGION_SIZE  SPU_SRAM_REGION_SIZE
 
+#define FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID 0
+#define SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID  64
+
 #define NUM_FLASH_SECURE_ATTRIBUTION_REGIONS \
 	(FLASH_TOTAL_SIZE / FLASH_SECURE_ATTRIBUTION_REGION_SIZE)
 #define NUM_SRAM_SECURE_ATTRIBUTION_REGIONS \
@@ -156,6 +159,66 @@ void spu_regions_flash_config_non_secure_callable(uint32_t start_addr,
 		FLASH_NSC_SIZE_REG(nsc_size),
 		FLASH_NSC_REGION_FROM_ADDR(start_addr),
 		1 /* Lock */);
+}
+
+uint32_t spu_regions_flash_get_base_address_in_region(uint32_t region_id)
+{
+	return FLASH_BASE_ADDRESS +
+		((region_id - FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID) *
+			FLASH_SECURE_ATTRIBUTION_REGION_SIZE);
+}
+
+uint32_t spu_regions_flash_get_last_address_in_region(uint32_t region_id)
+{
+	return FLASH_BASE_ADDRESS +
+		((region_id - FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID + 1) *
+			FLASH_SECURE_ATTRIBUTION_REGION_SIZE) - 1;
+}
+
+uint32_t spu_regions_flash_get_start_id(void) {
+
+	return FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID;
+}
+
+uint32_t spu_regions_flash_get_last_id(void) {
+
+	return FLASH_SECURE_ATTRIBUTION_REGIONS_START_ID +
+		NUM_FLASH_SECURE_ATTRIBUTION_REGIONS - 1;
+}
+
+uint32_t spu_regions_flash_get_region_size(void) {
+
+	return FLASH_SECURE_ATTRIBUTION_REGION_SIZE;
+}
+
+uint32_t spu_regions_sram_get_base_address_in_region(uint32_t region_id)
+{
+	return SRAM_BASE_ADDRESS +
+		((region_id - SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID) *
+			SRAM_SECURE_ATTRIBUTION_REGION_SIZE);
+}
+
+uint32_t spu_regions_sram_get_last_address_in_region(uint32_t region_id)
+{
+	return SRAM_BASE_ADDRESS +
+		((region_id - SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID + 1) *
+			SRAM_SECURE_ATTRIBUTION_REGION_SIZE) - 1;
+}
+
+uint32_t spu_regions_sram_get_start_id(void) {
+
+	return SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID;
+}
+
+uint32_t spu_regions_sram_get_last_id(void) {
+
+	return SRAM_SECURE_ATTRIBUTION_REGIONS_START_ID +
+		NUM_SRAM_SECURE_ATTRIBUTION_REGIONS - 1;
+}
+
+uint32_t spu_regions_sram_get_region_size(void) {
+
+	return SRAM_SECURE_ATTRIBUTION_REGION_SIZE;
 }
 
 void spu_peripheral_config_secure(uint32_t periph_base_addr, bool periph_lock)

--- a/platform/ext/target/nordic_nrf/common/native_drivers/spu.h
+++ b/platform/ext/target/nordic_nrf/common/native_drivers/spu.h
@@ -141,4 +141,90 @@ static inline void spu_gpio_config_non_secure(uint8_t port_number,
     nrf_spu_gpio_config_set(NRF_SPU, port_number, 0x0, gpio_lock);
 }
 
+/**
+ * \brief Return base address of a Flash SPU regions
+ *
+ * Get the base (lowest) address of a particular Flash SPU region
+ *
+ * \param region_id Valid flash SPU region ID
+ *
+ * \return the base address of the given flash SPU region
+ */
+uint32_t spu_regions_flash_get_base_address_in_region(uint32_t region_id);
+
+/**
+ * \brief Return last address of a Flash SPU regions
+ *
+ * Get the last (highest) address of a particular Flash SPU region
+ *
+ * \param region_id Valid flash SPU region ID
+ *
+ * \return the last address of the given flash SPU region
+ */
+uint32_t spu_regions_flash_get_last_address_in_region(uint32_t region_id);
+
+/**
+ * \brief Return the ID of the first Flash SPU region
+ *
+ * \return the first Flash region ID
+ */
+uint32_t spu_regions_flash_get_start_id(void);
+
+/**
+ * \brief Return the ID of the last Flash SPU region
+ *
+ * \return the last Flash region ID
+ */
+uint32_t spu_regions_flash_get_last_id(void);
+
+/**
+ * \brief Return the size of Flash SPU regions
+ *
+ * \return the size of Flash SPU regions
+ */
+uint32_t spu_regions_flash_get_region_size(void);
+
+/**
+ * \brief Return base address of a SRAM SPU regions
+ *
+ * Get the base (lowest) address of a particular SRAM SPU region
+ *
+ * \param region_id Valid SRAM SPU region ID
+ *
+ * \return the base address of the given SRAM SPU region
+ */
+uint32_t spu_regions_sram_get_base_address_in_region(uint32_t region_id);
+
+/**
+ * \brief Return last address of a SRAM SPU regions
+ *
+ * Get the last (highest) address of a particular SRAM SPU region
+ *
+ * \param region_id Valid SRAM SPU region ID
+ *
+ * \return the last address of the given SRAM SPU region
+ */
+uint32_t spu_regions_sram_get_last_address_in_region(uint32_t region_id);
+
+/**
+ * \brief Return the ID of the first SRAM SPU region
+ *
+ * \return the first SRAM region ID
+ */
+uint32_t spu_regions_sram_get_start_id(void);
+
+/**
+ * \brief Return the ID of the last SRAM SPU region
+ *
+ * \return the last SRAM region ID
+ */
+uint32_t spu_regions_sram_get_last_id(void);
+
+/**
+ * \brief Return the size of SRAM SPU regions
+ *
+ * \return the size of SRAM SPU regions
+ */
+uint32_t spu_regions_sram_get_region_size(void);
+
 #endif

--- a/platform/ext/target/nordic_nrf/common/spm_hal.c
+++ b/platform/ext/target/nordic_nrf/common/spm_hal.c
@@ -321,3 +321,68 @@ enum tfm_plat_err_t tfm_spm_hal_nvic_interrupt_enable(void)
 {
     return nvic_interrupt_enable();
 }
+
+bool tfm_spm_hal_has_access_to_region(const void *p, size_t s,
+                                              int flags)
+{
+    cmse_address_info_t tt_base = cmse_TT((void *)p);
+    cmse_address_info_t tt_last = cmse_TT((void *)((uint32_t)p + s - 1));
+
+    uint32_t base_spu_id = tt_base.flags.idau_region;
+    uint32_t last_spu_id = tt_last.flags.idau_region;
+
+    size_t size;
+    uint32_t p_start = (uint32_t)p;
+    int i;
+
+    if ((base_spu_id >= spu_regions_flash_get_start_id()) &&
+        (last_spu_id <= spu_regions_flash_get_last_id())) {
+
+        size = spu_regions_flash_get_last_address_in_region(base_spu_id) + 1 - p_start;
+
+        if (cmse_check_address_range((void *)p_start, size, flags) == 0) {
+            return false;
+        }
+
+        for (i = base_spu_id + 1; i < last_spu_id; i++) {
+            p_start = spu_regions_flash_get_base_address_in_region(i);
+            if (cmse_check_address_range((void *)p_start,
+                spu_regions_flash_get_region_size(), flags) == 0) {
+                return false;
+            }
+        }
+
+        p_start = spu_regions_flash_get_base_address_in_region(last_spu_id);
+        size = (uint32_t)p + s - p_start;
+        if (cmse_check_address_range((void *)p_start, size, flags) == 0) {
+            return false;
+        }
+
+
+    } else if ((base_spu_id >= spu_regions_sram_get_start_id()) &&
+        (last_spu_id <= spu_regions_sram_get_last_id())) {
+
+        size = spu_regions_sram_get_last_address_in_region(base_spu_id) + 1 - p_start;
+        if (cmse_check_address_range((void *)p_start, size, flags) == 0) {
+            return false;
+        }
+
+        for (i = base_spu_id + 1; i < last_spu_id; i++) {
+            p_start = spu_regions_sram_get_base_address_in_region(i);
+            if (cmse_check_address_range((void *)p_start,
+                spu_regions_sram_get_region_size(), flags) == 0) {
+                return false;
+            }
+        }
+
+        p_start = spu_regions_sram_get_base_address_in_region(last_spu_id);
+        size = (uint32_t)p + s - p_start;
+        if (cmse_check_address_range((void *)p_start, size, flags) == 0) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    return true;
+}

--- a/platform/include/tfm_spm_hal.h
+++ b/platform/include/tfm_spm_hal.h
@@ -318,4 +318,22 @@ void tfm_spm_hal_get_ns_access_attr(const void *p, size_t s,
 
 #endif /*TFM_MULTI_CORE_TOPOLOGY*/
 
+#if !defined(__SAUREGION_PRESENT) || (__SAUREGION_PRESENT == 0)
+/**
+ * \brief Platform-specific check whether the current partition has access to a memory range
+ *
+ * The function checks whether the current partition has access to a memory range,
+ * taking into consideration the implementation-defined attribution unit that is
+ * present on a particular platform.
+ *
+ * \param[in] p      The start address of the range to check
+ * \param[in] s      The size of the range to check
+ * \param[in] flags  The flags to pass to the cmse_check_address_range func
+ *
+ * \return Trus if the access is granted, false otherwise.
+ */
+bool tfm_spm_hal_has_access_to_region(const void *p, size_t s,
+                                              int flags);
+#endif /* !defined(__SAUREGION_PRESENT) || (__SAUREGION_PRESENT == 0) */
+
 #endif /* __TFM_SPM_HAL_H__ */

--- a/secure_fw/core/tfm_core_mem_check.c
+++ b/secure_fw/core/tfm_core_mem_check.c
@@ -8,6 +8,7 @@
 #include <arm_cmse.h>
 #include "region_defs.h"
 #include "secure_fw/spm/spm_api.h"
+#include "tfm_spm_hal.h"
 #include "tfm_api.h"
 
 /**
@@ -34,6 +35,25 @@ static enum tfm_status_e has_access_to_region(const void *p, size_t s,
     /* Use the TT instruction to check access to the partition's regions*/
     range_access_allowed_by_mpu =
                           cmse_check_address_range((void *)p, s, flags) != NULL;
+
+#if !defined(__SAUREGION_PRESENT) || (__SAUREGION_PRESENT == 0)
+    if (!range_access_allowed_by_mpu) {
+        /*
+         * Verification failure may be due to address range crossing
+         * one or multiple IDAU boundaries. In this case request a
+         * platform-specific check for access permissions.
+         */
+        cmse_address_info_t addr_info_base = cmse_TT((void *)p);
+        cmse_address_info_t addr_info_last = cmse_TT((void *)((uint32_t)p + s - 1));
+
+        if ((addr_info_base.flags.idau_region_valid != 0) &&
+            (addr_info_last.flags.idau_region_valid != 0) &&
+            (addr_info_base.flags.idau_region != addr_info_last.flags.idau_region)) {
+                range_access_allowed_by_mpu =
+                    tfm_spm_hal_has_access_to_region(p, s, flags);
+            }
+    }
+#endif
 
     if (range_access_allowed_by_mpu) {
         return TFM_SUCCESS;


### PR DESCRIPTION
We enhance the implementation of has_access_to_region(), so
it works with IDAU implementations, i.e. other than the ARM
SAU.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>